### PR TITLE
Fix: Added GWTC-4.0 to list of catalogues and added Dynaconf for flexibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "astropy",
     "astroquery",
     "pandas>=2.0",
-    "rdflib"
+    "rdflib",
+    "dynaconf"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -156,4 +156,4 @@ def test_byname_11_same_source_different_name(client, source_name):
     assert 'object_ids' in jdata
     assert 'main_id' in jdata
 
-    assert jdata['main_id'] == 'Mrk  421'
+    assert jdata['main_id'] == 'Z 184-50'

--- a/tnr/config.py
+++ b/tnr/config.py
@@ -1,0 +1,7 @@
+from dynaconf import Dynaconf
+
+settings = Dynaconf(
+    envvar_prefix="TNR",
+    settings_files=['settings.toml', '.secrets.toml'],
+    load_dotenv=True,
+)

--- a/tnr/plugins/gwproxy.py
+++ b/tnr/plugins/gwproxy.py
@@ -1,11 +1,14 @@
 import requests
 from tnr.resolvers import Resolver
-import os
+from tnr.config import settings
 from astropy.time import Time
 
-plugin_enabled = os.environ.get('TNR_PLUGIN_GWPROXY_ENABLED','no') == 'yes'
+plugin_enabled_config = settings.get('PLUGIN_GWPROXY_ENABLED', 'no')
+plugin_enabled = str(plugin_enabled_config).lower() in ['yes', 'true']
+
 resolveurl = "https://www.gw-openscience.org/eventapi/json/query/show?name-contains={name}"
-used_catalogs = ['GWTC-1-confident', 'GWTC-2', 'GWTC-3-confident']
+confident_catalogues = ['GWTC-4.0', 'GWTC-1-confident', 'GWTC-2', 'GWTC-3-confident']
+used_catalogs = settings.get('GWPROXY_CATALOGS', confident_catalogues)
 
 class GWProxyResolver(Resolver):
         


### PR DESCRIPTION
Added tnr/config.py which handles Dynaconf configuration from settings and secrets. 
For used-catalogues GWTC-4.0 was added (and tested). Also now catalogues might be aquired from Dynaconf directly (in case of one or two catalogues defined instead of all hardcoded).